### PR TITLE
Rewrite README for this site and fix stale domain in sitemap

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,322 +1,66 @@
-# minima
+# 福生當鋪官方網站
 
-*Minima is a one-size-fits-all Jekyll theme for writers*. It's Jekyll's default (and first) theme. It's what you get when you run `jekyll new`.
+福生當鋪的官方網站，提供店家介紹、服務項目、聯絡方式與營業時間等資訊。
 
-***Disclaimer:** The information here may vary depending on the version you're using. Please refer to the `README.md` bundled
-within the theme-gem for information specific to your version or by pointing your browser to the Git tag corresponding to your
-version. e.g. https://github.com/jekyll/minima/blob/v2.5.0/README.md*  
-*Running `bundle show minima` will provide you with the local path to your current theme version.*
+- 網址：<https://fusheng-pawnshop.com>
+- 店址：雲林縣斗六市大學路一段527號
+- 電話：(05)5339997
+- 營業時間：週一至週五 早上 9:00 – 晚上 6:00（週六、週日休息）
 
+網站以 [Jekyll](https://jekyllrb.com/) 建置，基於 [minima](https://github.com/jekyll/minima) 佈景主題（3.0 開發版）修改而成，透過 GitHub Pages 部署。
 
-[Theme preview](https://jekyll.github.io/minima/)
+## 網站頁面
 
-![minima theme preview](/screenshot.png)
+| 頁面 | 檔案 | 網址 | 說明 |
+| --- | --- | --- | --- |
+| 首頁 | `index.md` | <https://fusheng-pawnshop.com/> | 文章列表首頁（`home` layout） |
+| 關於 | `about.md` | <https://fusheng-pawnshop.com/about/> | 店家介紹（合法當鋪、政府立案） |
+| 服務特點及項目 | `business_type.md` | <https://fusheng-pawnshop.com/buinese_type/> | 服務特點（認證、專業、服務）與服務項目（土地房屋貸款、汽機車、工商融資、金飾） |
+| 文章 | `_posts/` | — | 部落格文章 |
 
-## Installation
+頁尾（`_includes/footer.html`）會顯示聯絡資訊、營業時間、Facebook 連結與 Google 地圖。
 
-Add this line to your Jekyll site's Gemfile:
-
-```ruby
-gem "minima"
-```
-
-And then execute:
-
-    $ bundle
-
-
-## Contents At-A-Glance
-
-Minima has been scaffolded by the `jekyll new-theme` command and therefore has all the necessary files and directories to have a new Jekyll site up and running with zero-configuration.
-
-### Layouts
-
-Refers to files within the `_layouts` directory, that define the markup for your theme.
-
-  - `default.html` &mdash; The base layout that lays the foundation for subsequent layouts. The derived layouts inject their contents into this file at the line that says ` {{ content }} ` and are linked to this file via [FrontMatter](https://jekyllrb.com/docs/frontmatter/) declaration `layout: default`.
-  - `home.html` &mdash; The layout for your landing-page / home-page / index-page. [[More Info.](#home-layout)]
-  - `page.html` &mdash; The layout for your documents that contain FrontMatter, but are not posts.
-  - `post.html` &mdash; The layout for your posts.
-
-#### Home Layout
-
-`home.html` is a flexible HTML layout for the site's landing-page / home-page / index-page. <br/>
-
-##### *Main Heading and Content-injection*
-
-From Minima v2.2 onwards, the *home* layout will inject all content from your `index.md` / `index.html` **before** the **`Posts`** heading. This will allow you to include non-posts related content to be published on the landing page under a dedicated heading. *We recommended that you title this section with a Heading2 (`##`)*.
-
-Usually the `site.title` itself would suffice as the implicit 'main-title' for a landing-page. But, if your landing-page would like a heading to be explicitly displayed, then simply define a `title` variable in the document's front matter and it will be rendered with an `<h1>` tag.
-
-##### *Post Listing*
-
-This section is optional from Minima v2.2 onwards.<br/>
-It will be automatically included only when your site contains one or more valid posts or drafts (if the site is configured to `show_drafts`).
-
-The title for this section is `Posts` by default and rendered with an `<h2>` tag. You can customize this heading by defining a `list_title` variable in the document's front matter.
-
-
-### Includes
-
-Refers to snippets of code within the `_includes` directory that can be inserted in multiple layouts (and another include-file as well) within the same theme-gem.
-
-  - `disqus_comments.html` &mdash; Code to markup disqus comment box.
-  - `footer.html` &mdash; Defines the site's footer section.
-  - `google-analytics.html` &mdash; Inserts Google Analytics module (active only in production environment).
-  - `head.html` &mdash; Code-block that defines the `<head></head>` in *default* layout.
-  - `custom-head.html` &mdash; Placeholder to allow users to add more metadata to `<head />`.
-  - `header.html` &mdash; Defines the site's main header section. By default, pages with a defined `title` attribute will have links displayed here.
-  - `social.html` &mdash; Renders social-media icons based on the `minima:social_links` data in the config file.
-
-
-### Sass
-
-Refers to `.scss` files within the `_sass` directory that define the theme's styles.
-
-  - `minima/skins/classic.scss` &mdash; The "classic" skin of the theme. *Used by default.*
-  - `minima/initialize.scss` &mdash; A component that defines the theme's *skin-agnostic* variable defaults and sass partials.
-    It imports the following components (in the following order):
-    - `minima/custom-variables.scss` &mdash; A hook that allows overriding variable defaults and mixins. (*Note: Cannot override styles*)
-    - `minima/_base.scss` &mdash; Sass partial for resets and defines base styles for various HTML elements.
-    - `minima/_layout.scss` &mdash; Sass partial that defines the visual style for various layouts.
-    - `minima/custom-styles.scss` &mdash; A hook that allows overriding styles defined above. (*Note: Cannot override variables*)
-
-Refer the [skins](#skins) section for more details.
-
-
-### Assets
-
-Refers to various asset files within the `assets` directory.
-
-  - `assets/css/style.scss` &mdash; Imports sass files from within the `_sass` directory and gets processed into the theme's
-    stylesheet: `assets/css/styles.css`.
-  - `assets/minima-social-icons.svg` &mdash; A composite SVG file comprised of *symbols* related to various social-media icons.
-    This file is used as-is without any processing. Refer [section on social networks](#social-networks) for its usage.
-
-
-### Plugins
-
-Minima comes with [`jekyll-seo-tag`](https://github.com/jekyll/jekyll-seo-tag) plugin preinstalled to make sure your website gets the most useful meta tags. See [usage](https://github.com/jekyll/jekyll-seo-tag#usage) to know how to set it up.
-
-
-## Usage
-
-Have the following line in your config file:
-
-```yaml
-theme: minima
-```
-
-
-### Customizing templates
-
-To override the default structure and style of minima, simply create the concerned directory at the root of your site, copy the file you wish to customize to that directory, and then edit the file.
-e.g., to override the [`_includes/head.html `](_includes/head.html) file to specify a custom style path, create an `_includes` directory, copy `_includes/head.html` from minima gem folder to `<yoursite>/_includes` and start editing that file.
-
-The site's default CSS has now moved to a new place within the gem itself, [`assets/css/style.scss`](assets/css/style.scss).
-
-In Minima 3.0, if you only need to customize the colors of the theme, refer to the subsequent section on skins. To have your
-*CSS overrides* in sync with upstream changes released in future versions, you can collect all your overrides for the Sass
-variables and mixins inside a sass file placed at `_sass/minima/custom-variables.scss` and all other overrides inside a sass file
-placed at path `_sass/minima/custom.scss`.
-
-You need not maintain entire partial(s) at the site's source just to override a few styles. However, your stylesheet's primary
-source (`assets/css/style.scss`) should contain the following:
-
-  - Front matter dashes at the very beginning (can be empty).
-  - Directive to import a skin.
-  - Directive to import the base styles (automatically loads overrides when available).
-
-Therefore, your `assets/css/style.scss` should contain the following at minimum:
-
-```sass
----
----
-
-@import "minima/skins/{{ site.minima.skin | default: 'classic' }}";
-@import "minima/initialize";
-```
-
-#### Skins
-
-Minima 3.0 supports defining and switching between multiple color-palettes (or *skins*).
+## 專案結構
 
 ```
 .
-├── minima.scss
-└── minima
-    └── _syntax-highlighting.scss
+├── _config.yml          # 網站設定：店名、電話、地址、營業時間開關、社群連結
+├── _includes/           # 頁面片段（header、footer、head 等）
+│   └── footer.html      # 自訂頁尾：聯絡資訊、營業時間、Google 地圖嵌入
+├── _layouts/            # 頁面版型（default、home、page、post）
+├── _posts/              # 部落格文章（檔名格式：YYYY-MM-DD-標題.md）
+├── _sass/               # 佈景主題樣式（minima）
+├── assets/              # 主題樣式進入點與社群 icon
+├── css/                 # business_type 頁面的自訂樣式
+├── svg/                 # 服務特點與服務項目的圖示
+├── CNAME                # GitHub Pages 自訂網域（fusheng-pawnshop.com）
+├── sitemap.xml          # 搜尋引擎 sitemap
+└── google*.html         # Google Search Console 驗證檔
 ```
 
+## 修改網站內容
 
-A skin is a Sass file placed in the directory `_sass/minima/skins` and it defines the variable defaults related to the "color"
-aspect of the theme. It also embeds the Sass rules related to syntax-highlighting since that is primarily related to color and
-has to be adjusted in harmony with the current skin.
+- **聯絡資訊／營業時間**：電話與地址在 `_config.yml` 的 `author` 區塊；營業時間的文字寫在 `_includes/footer.html`，可用 `_config.yml` 的 `businese_hours: true/false` 開關整個區塊。
+- **服務項目**：編輯 `business_type.md`，圖示放在 `svg/` 目錄。
+- **新增文章**：在 `_posts/` 新增 `YYYY-MM-DD-標題.md`，front matter 設定 `layout: post`。
+- **社群連結**：`_config.yml` 的 `minima.social_links`（目前只啟用 Facebook）。
+- **樣式調整**：全站樣式覆寫放在 `_sass/minima/custom-variables.scss` 與 `_sass/minima/custom-styles.scss`；`business_type` 頁面另有獨立的 `css/business_type.css`。
 
-The default color palette for Minima is defined within `_sass/minima/skins/classic.scss`. To switch to another available skin,
-simply declare it in the site's config file. For example, to activate `_sass/minima/skins/dark.scss` as the skin, the setting
-would be:
+## 本機開發
 
-```yaml
-minima:
-  skin: dark
+需要 Ruby 與 Bundler。
+
+```bash
+bundle install
+bundle exec jekyll serve   # 或執行 script/server
 ```
 
-As part of the migration to support skins, some existing Sass variables have been retired and some **have been redefined** as
-summarized in the following table:
+啟動後開啟 <http://localhost:4000> 預覽，修改檔案會自動重新產生頁面。
 
-Minima 2.0      | Minima 3.0
---------------- | ----------
-`$brand-color`  | `$link-base-color`
-`$grey-*`       | `$brand-*`
-`$orange-color` | *has been removed*
+## 部署
 
-##### Available skins
+推送到 `master` 分支後，GitHub Pages 會自動建置並發布至 `fusheng-pawnshop.com`（由 `CNAME` 檔指定網域）。
 
-- classic
-- dark
-- solarized
-- solarized-dark
+## 授權
 
-### Customize navigation links
-
-This allows you to set which pages you want to appear in the navigation area and configure order of the links.
-
-For instance, to only link to the `about` and the `portfolio` page, add the following to your `_config.yml`:
-
-```yaml
-header_pages:
-  - about.md
-  - portfolio.md
-```
-
-
-### Change default date format
-
-You can change the default date format by specifying `site.minima.date_format`
-in `_config.yml`.
-
-```
-# Minima date format
-# refer to http://shopify.github.io/liquid/filters/date/ if you want to customize this
-minima:
-  date_format: "%b %-d, %Y"
-```
-
-
-### Extending the `<head />`
-
-You can *add* custom metadata to the `<head />` of your layouts by creating a file `_includes/custom-head.html` in your source directory. For example, to add favicons:
-
-1. Head over to [https://realfavicongenerator.net/](https://realfavicongenerator.net/) to add your own favicons.
-2. [Customize](#customization) default `_includes/custom-head.html` in your source directory and insert the given code snippet.
-
-
-### Enabling comments (via Disqus)
-
-Optionally, if you have a Disqus account, you can tell Jekyll to use it to show a comments section below each post.
-
-To enable it, add the following lines to your Jekyll site:
-
-```yaml
-  disqus:
-    shortname: my_disqus_shortname
-```
-
-You can find out more about Disqus' shortnames [here](https://help.disqus.com/installation/whats-a-shortname).
-
-Comments are enabled by default and will only appear in production, i.e., `JEKYLL_ENV=production`
-
-If you don't want to display comments for a particular post you can disable them by adding `comments: false` to that post's YAML Front Matter.
-
-:warning: `url`, e.g. `https://example.com`, must be set in you config file for Disqus to work.
-
-### Author Metadata
-
-From `Minima-3.0` onwards, `site.author` is expected to be a mapping of attributes instead of a simple scalar value:
-
-```yaml
-author:
-  name: John Smith
-  email: "john.smith@foobar.com"
-```
-
-To migrate existing metadata, update your config file and any reference to the object in your layouts and includes as summarized below:
-
-Minima 2.x    | Minima 3.0
-------------- | -------------------
-`site.author` | `site.author.name`
-`site.email`  | `site.author.email`
-
-
-### Social networks
-
-You can add links to the accounts you have on other sites, with respective icon, by adding one or more of the following options in your config.
-From `Minima-3.0` onwards, the usernames are to be nested under `minima.social_links`, with the keys being simply the social-network's name:
-
-```yaml
-minima:
-  social_links:
-    twitter: jekyllrb
-    github: jekyll
-    stackoverflow: "11111"
-    dribbble: jekyll
-    facebook: jekyll
-    flickr: jekyll
-    instagram: jekyll
-    linkedin: jekyll
-    pinterest: jekyll
-    telegram: jekyll
-    microdotblog: jekyll
-    keybase: jekyll
-
-    mastodon:
-     - username: jekyll
-       instance: example.com
-     - username: jekyll2
-       instance: example.com
-
-    gitlab:
-     - username: jekyll
-       instance: example.com
-     - username: jekyll2
-       instance: example.com
-
-    youtube: jekyll
-    youtube_channel: UC8CXR0-3I70i1tfPg1PAE1g
-    youtube_channel_name: CloudCannon
-```
-
-
-### Enabling Google Analytics
-
-To enable Google Analytics, add the following lines to your Jekyll site:
-
-```yaml
-  google_analytics: UA-NNNNNNNN-N
-```
-
-Google Analytics will only appear in production, i.e., `JEKYLL_ENV=production`
-
-### Enabling Excerpts on the Home Page
-
-To display post-excerpts on the Home Page, simply add the following to your `_config.yml`:
-
-```yaml
-show_excerpts: true
-```
-
-
-## Contributing
-
-Bug reports and pull requests are welcome on GitHub at https://github.com/jekyll/minima. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct.
-
-## Development
-
-To set up your environment to develop this theme, run `script/bootstrap`.
-
-To test your theme, run `script/server` (or `bundle exec jekyll serve`) and open your browser at `http://localhost:4000`. This starts a Jekyll server using your theme and the contents. As you make modifications, your site will regenerate and you should see the changes in the browser after a refresh.
-
-## License
-
-The theme is available as open source under the terms of the [MIT License](http://opensource.org/licenses/MIT).
+佈景主題 minima 依 [MIT License](LICENSE.txt) 授權。

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -8,22 +8,22 @@
 
 
 <url>
-  <loc>https://fushengs.com/</loc>
+  <loc>https://fusheng-pawnshop.com/</loc>
   <lastmod>2021-03-07T15:04:55+00:00</lastmod>
   <priority>1.00</priority>
 </url>
 <url>
-  <loc>https://fushengs.com/about/</loc>
+  <loc>https://fusheng-pawnshop.com/about/</loc>
   <lastmod>2021-03-07T15:04:55+00:00</lastmod>
   <priority>0.80</priority>
 </url>
 <url>
-  <loc>https://fushengs.com/buinese_type/</loc>
+  <loc>https://fusheng-pawnshop.com/buinese_type/</loc>
   <lastmod>2021-03-07T15:04:55+00:00</lastmod>
   <priority>0.80</priority>
 </url>
 <url>
-  <loc>https://fushengs.com/2021/03/03/%E6%AD%A1%E8%BF%8E%E4%BE%86%E5%88%B0%E7%A6%8F%E7%94%9F%E7%95%B6%E9%8B%AA.html</loc>
+  <loc>https://fusheng-pawnshop.com/2021/03/03/%E6%AD%A1%E8%BF%8E%E4%BE%86%E5%88%B0%E7%A6%8F%E7%94%9F%E7%95%B6%E9%8B%AA.html</loc>
   <lastmod>2021-03-07T15:04:55+00:00</lastmod>
   <priority>0.80</priority>
 </url>


### PR DESCRIPTION
The README was still the stock minima theme README. Replace it with documentation for the actual project: the 福生當鋪 website, its pages, project structure, content-editing guide, local development, and deployment via GitHub Pages.

Also update sitemap.xml URLs from the old fushengs.com domain to the current fusheng-pawnshop.com (matching CNAME).