### PR TITLE
Improve page load speed and make business_type page responsive

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -55,6 +55,9 @@ minima:
 # Build settings
 theme: minima
 
+sass:
+  style: compressed
+
 plugins:
  #- jekyll-feed
  - jekyll-seo-tag

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -44,7 +44,25 @@
       </div>
       <div class="footer-col">
 <!--         <p>{{ site.description | escape }}</p> -->
-        <iframe src="https://www.google.com/maps/embed?pb=!1m14!1m8!1m3!1d14612.654746630464!2d120.555505!3d23.705848!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x0%3A0x9750e27d7dca904d!2z56aP55Sf55W26IiW!5e0!3m2!1szh-TW!2stw!4v1614593659869!5m2!1szh-TW!2stw" width="300" height="300" style="border:0;" allowfullscreen="" loading="lazy"></iframe>
+        <div class="map-embed" id="map-embed">
+          <button type="button" class="map-load-btn" id="map-load-btn">📍 顯示地圖</button>
+          <p class="map-open-link">
+            <a href="https://www.google.com/maps/search/?api=1&amp;query=%E7%A6%8F%E7%94%9F%E7%95%B6%E8%88%96%20%E9%9B%B2%E6%9E%97%E7%B8%A3%E6%96%97%E5%85%AD%E5%B8%82%E5%A4%A7%E5%AD%B8%E8%B7%AF%E4%B8%80%E6%AE%B5527%E8%99%9F" target="_blank" rel="noopener">在 Google Maps 開啟</a>
+          </p>
+        </div>
+        <script>
+          document.getElementById('map-load-btn').addEventListener('click', function () {
+            var container = document.getElementById('map-embed');
+            var iframe = document.createElement('iframe');
+            iframe.src = 'https://www.google.com/maps/embed?pb=!1m14!1m8!1m3!1d14612.654746630464!2d120.555505!3d23.705848!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x0%3A0x9750e27d7dca904d!2z56aP55Sf55W26IiW!5e0!3m2!1szh-TW!2stw!4v1614593659869!5m2!1szh-TW!2stw';
+            iframe.width = '300';
+            iframe.height = '300';
+            iframe.style.border = '0';
+            iframe.loading = 'lazy';
+            iframe.allowFullscreen = true;
+            container.replaceChildren(iframe);
+          });
+        </script>
       </div>
     </div>
 

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -4,7 +4,6 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   {%- seo -%}
   <link rel="stylesheet" href="{{ "/assets/css/style.css" | relative_url }}">
-  {%- feed_meta -%}
   {%- if jekyll.environment == 'production' and site.google_analytics -%}
     {%- include google-analytics.html -%}
   {%- endif -%}

--- a/_sass/minima/custom-styles.scss
+++ b/_sass/minima/custom-styles.scss
@@ -1,2 +1,28 @@
 // Placeholder to allow defining custom styles that override everything else.
 // (Use `_sass/minima/custom-variables.scss` to override variable defaults)
+
+.map-embed {
+  iframe {
+    max-width: 100%;
+  }
+
+  .map-load-btn {
+    display: block;
+    padding: 12px 24px;
+    font-size: 16px;
+    cursor: pointer;
+    border: 1px solid $border-color-01;
+    border-radius: 4px;
+    background-color: $background-color;
+    color: $text-color;
+
+    &:hover {
+      border-color: $link-base-color;
+      color: $link-base-color;
+    }
+  }
+
+  .map-open-link {
+    margin-top: 8px;
+  }
+}

--- a/css/business_type.css
+++ b/css/business_type.css
@@ -1,25 +1,53 @@
-.container{
-  width: 900px;
+.container {
+  width: 100%;
+  max-width: 900px;
   margin: 0 auto;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
 }
-.icon{
-  position: relative;
-  width: 270px;
-  float:left;
+.bigtitle {
+  flex-basis: 100%;
+  font-size: 40px;
+}
+.icon {
+  flex: 1 1 220px;
+  max-width: 270px;
   margin: 10px;
 }
-.center {
+.icon img {
   display: block;
   margin-left: auto;
   margin-right: auto;
   width: 50%;
+  max-width: 100px;
+  height: auto;
 }
-.bigtitle{
-	font-size: 40px;
+.bigtitle p {
+  margin-bottom: 0;
 }
-.subtitle{
-	font-size: 30px;
+.subtitle {
+  font-size: 30px;
 }
-.context{
-	font-size: 20px;
+.context {
+  font-size: 20px;
+}
+
+@media screen and (max-width: 600px) {
+  .bigtitle {
+    font-size: 28px;
+  }
+  .subtitle {
+    font-size: 22px;
+  }
+  .context {
+    font-size: 16px;
+  }
+  .icon {
+    flex: 1 1 40%;
+    margin: 8px 4px;
+  }
+  .icon img {
+    max-width: 72px;
+  }
 }


### PR DESCRIPTION
Performance:
- Replace the always-loaded Google Maps iframe in the footer with a click-to-load button plus a direct Google Maps link, saving ~1MB of map JavaScript on every page view.
- Remove feed_meta from head.html (RSS feed is not enabled).
- Enable compressed Sass output.

Mobile responsiveness:
- Rewrite css/business_type.css: fixed 900px container and floated 270px cards replaced with a wrapping flexbox layout; images sized with max-width/height:auto; media query adjusts font sizes under 600px. Verified at 375px (2 cards per row, no horizontal overflow), 500px, and 1280px (3 cards per row).
- Constrain footer map embed to max-width:100%.