### PR TITLE
Load above-the-fold service icons eagerly

### DIFF
--- a/business_type.md
+++ b/business_type.md
@@ -7,17 +7,17 @@ permalink: /buinese_type/
 	<h2 class="fs-section-title">服務特點</h2>
 	<div class="fs-cards">
 		<div class="fs-card">
-			<img src="/svg/feature/goverment.svg" alt="政府立案" loading="lazy">
+			<img src="/svg/feature/goverment.svg" alt="政府立案">
 			<h3>政府立案</h3>
 			<p>領有雲林縣政府當舖業許可證與營利事業登記證,並經當舖公會認證,合法經營、誠信保密,個人隱私絕無洩漏可能。</p>
 		</div>
 		<div class="fs-card">
-			<img src="/svg/feature/briefcase-fill.svg" alt="專業鑑定" loading="lazy">
+			<img src="/svg/feature/briefcase-fill.svg" alt="專業鑑定">
 			<h3>專業鑑定</h3>
 			<p>提供免費的專業鑑定,包含黃金、金飾、汽車、機車,估價公道透明,不隨意殺價。</p>
 		</div>
 		<div class="fs-card">
-			<img src="/svg/feature/hand-shake.svg" alt="快速放款" loading="lazy">
+			<img src="/svg/feature/hand-shake.svg" alt="快速放款">
 			<h3>快速放款</h3>
 			<p>服務優良、放款快速且手續簡單,息低簡便,讓您安心借款、典當。</p>
 		</div>
@@ -28,17 +28,17 @@ permalink: /buinese_type/
 	<h2 class="fs-section-title">服務項目</h2>
 	<div class="fs-cards">
 		<div class="fs-card">
-			<img src="/svg/service/car.svg" alt="汽車借款" loading="lazy">
+			<img src="/svg/service/car.svg" alt="汽車借款">
 			<h3>汽車借款</h3>
 			<p><span class="fs-badge">免留車</span>不限廠牌、車種、車齡,分期車也可以借。免費估價、手續簡單,核貸後車輛照常使用,不影響工作與生活。</p>
 		</div>
 		<div class="fs-card">
-			<img src="/svg/service/bike.svg" alt="機車借款" loading="lazy">
+			<img src="/svg/service/bike.svg" alt="機車借款">
 			<h3>機車借款</h3>
 			<p><span class="fs-badge">免留車</span>不限車齡、車款,證件齊全即可快速辦理、當場放款,機車繼續騎,通勤不受影響。</p>
 		</div>
 		<div class="fs-card">
-			<img src="/svg/service/gold-ingots.svg" alt="黃金金飾借款" loading="lazy">
+			<img src="/svg/service/gold-ingots.svg" alt="黃金金飾借款">
 			<h3>黃金・金飾借款</h3>
 			<p>金飾、金條、戒指、項鍊、手鍊皆可典當。現場專業鑑定、秤重報價透明,高價收當。</p>
 		</div>

--- a/index.md
+++ b/index.md
@@ -17,17 +17,17 @@ layout: default
     <h2 class="fs-section-title">服務特點</h2>
     <div class="fs-cards">
       <div class="fs-card">
-        <img src="/svg/feature/goverment.svg" alt="政府立案" loading="lazy">
+        <img src="/svg/feature/goverment.svg" alt="政府立案">
         <h3>政府立案</h3>
         <p>領有雲林縣政府當舖業許可證與營利事業登記證,合法經營、誠信保密,個人隱私絕不外洩。</p>
       </div>
       <div class="fs-card">
-        <img src="/svg/feature/briefcase-fill.svg" alt="專業鑑定" loading="lazy">
+        <img src="/svg/feature/briefcase-fill.svg" alt="專業鑑定">
         <h3>專業鑑定</h3>
         <p>黃金、金飾、汽車、機車免費專業估價,價格公道透明,讓您典當得安心。</p>
       </div>
       <div class="fs-card">
-        <img src="/svg/feature/hand-shake.svg" alt="快速放款" loading="lazy">
+        <img src="/svg/feature/hand-shake.svg" alt="快速放款">
         <h3>快速放款</h3>
         <p>手續簡單、放款快速,息低簡便,資金週轉、臨時應急的最佳選擇。</p>
       </div>
@@ -38,17 +38,17 @@ layout: default
     <h2 class="fs-section-title">服務項目</h2>
     <div class="fs-cards">
       <div class="fs-card">
-        <img src="/svg/service/car.svg" alt="汽車借款" loading="lazy">
+        <img src="/svg/service/car.svg" alt="汽車借款">
         <h3>汽車借款</h3>
         <p><span class="fs-badge">免留車</span>不限車種、車齡,分期車可借,免費估價,車照常使用。</p>
       </div>
       <div class="fs-card">
-        <img src="/svg/service/bike.svg" alt="機車借款" loading="lazy">
+        <img src="/svg/service/bike.svg" alt="機車借款">
         <h3>機車借款</h3>
         <p><span class="fs-badge">免留車</span>手續簡便、快速放款,機車繼續騎,不影響通勤。</p>
       </div>
       <div class="fs-card">
-        <img src="/svg/service/gold-ingots.svg" alt="黃金金飾借款" loading="lazy">
+        <img src="/svg/service/gold-ingots.svg" alt="黃金金飾借款">
         <h3>黃金・金飾借款</h3>
         <p>金飾、金條、戒指、項鍊、手鍊皆可典當,現場免費鑑定、高價收當。</p>
       </div>


### PR DESCRIPTION
The six feature/service SVG icons had loading="lazy" but sit at the top of the homepage and services page; in some browsers the lazy load never fired and the icons rendered blank. They are under 3KB each, so lazy-loading them saved nothing. The below-the-fold certificate photos and the footer map keep lazy loading.