### PR TITLE
Make the footer Facebook link a prominent button

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -43,7 +43,12 @@
           <li>&nbsp;&nbsp;禮拜日 休息</li>
         </ul>
       {%- endif %}
-      {%- include social.html -%}
+      {%- if site.minima.social_links.facebook %}
+        <a class="fs-fb-btn" href="https://www.facebook.com/{{ site.minima.social_links.facebook | cgi_escape | escape }}" target="_blank" rel="noopener">
+          <svg class="svg-icon"><use xlink:href="{{ '/assets/minima-social-icons.svg#facebook' | relative_url }}"></use></svg>
+          <span>Facebook 粉絲專頁</span>
+        </a>
+      {%- endif %}
       </div>
       <div class="footer-col">
 <!--         <p>{{ site.description | escape }}</p> -->

--- a/_sass/minima/custom-styles.scss
+++ b/_sass/minima/custom-styles.scss
@@ -283,6 +283,36 @@ $fs-border: #e6e0d2;
   margin-top: 20px;
 }
 
+// ---- Facebook button ----
+.fs-fb-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 12px;
+  padding: 10px 20px;
+  border-radius: 8px;
+  background-color: #1877f2;
+  color: #ffffff;
+  font-size: 16px;
+  font-weight: bold;
+
+  .svg-icon {
+    width: 20px;
+    height: 20px;
+    fill: #ffffff;
+  }
+
+  &:visited {
+    color: #ffffff;
+  }
+
+  &:hover {
+    background-color: #1466d8;
+    color: #ffffff;
+    text-decoration: none;
+  }
+}
+
 // ---- Footer ----
 .site-footer {
   background-color: $fs-cream;


### PR DESCRIPTION
Replace the 16px grey social icon with a Facebook-blue button showing the icon plus a "Facebook 粉絲專頁" label, opening in a new tab. The generic social.html include is no longer used by the footer.